### PR TITLE
examples: Correct .gitignore for rotating-cube

### DIFF
--- a/examples/rotating-cube/.gitignore
+++ b/examples/rotating-cube/.gitignore
@@ -1,1 +1,1 @@
-anim
+rotating-cube


### PR DESCRIPTION
The wrong executable was ignored from tree.