### PR TITLE
TextRenderer: Implement dot-line-rendering

### DIFF
--- a/CE3D2/models/LineModel.h
+++ b/CE3D2/models/LineModel.h
@@ -53,7 +53,7 @@ namespace Models
 
         /// Constructs a unit-hypercube.
         ///
-        /// @param dimensions
+        /// @param dimension
         ///     The dimension of the hypercube.
         /// @throws std::invalid_argument
         ///     Thrown when dimension is 0 or less or it's so big that it

--- a/CE3D2/render/TextRenderer.cpp
+++ b/CE3D2/render/TextRenderer.cpp
@@ -54,6 +54,18 @@ namespace Render
     }
 
     std::vector<std::shared_ptr<CE3D2::Models::LineModel>>&
+    TextRenderer::dotline_models()
+    {
+        return m_DotlineModels;
+    }
+
+    std::vector<std::shared_ptr<CE3D2::Models::LineModel>> const&
+    TextRenderer::dotline_models() const
+    {
+        return m_DotlineModels;
+    }
+
+    std::vector<std::shared_ptr<CE3D2::Models::LineModel>>&
     TextRenderer::line_models()
     {
         return m_LineModels;
@@ -82,6 +94,193 @@ namespace Render
                     if (m_Target->is_boundary_valid(x, y))
                     {
                         (*m_Target)(x, y) = m_RenderChar;
+                    }
+                }
+            }
+        }
+    }
+
+    void
+    TextRenderer::render_dotlines()
+    {
+        CE3D2::Math::Box const viewbox(
+            static_cast<CE3D2::PrecisionType>(get_target()->width()),
+            static_cast<CE3D2::PrecisionType>(get_target()->height()));
+
+        for (auto const& model: m_DotlineModels)
+        {
+            if (model->is_visible())
+            {
+                for (auto const& indexpair: model->connections())
+                {
+                    auto const& v1 = model->vectors()[indexpair.first];
+                    auto const& v2 = model->vectors()[indexpair.second];
+
+                    // We need to distinct 4 different cases:
+                    // --> |x1 - x2| >= |y1 - y2|
+                    //     We iterate over x to leave no holes. This is equal
+                    //     to the condition `abs(gradient) <= 1`. If we would
+                    //     iterate over y, our function may jump over a
+                    //     character-field and we get char-holes.
+                    // --> |x1 - x2| < |y1 - y2|
+                    //     We iterate over y to leave no holes. Equal to the
+                    //     condition `abs(gradient) > 1`.
+                    // --> x1 == x2
+                    //     Normally this case should be covered from the
+                    //     previous one, but due to limitations inside our
+                    //     linear-function-object we can't correctly calculate
+                    //     the inverse, inside the inverse value calculations
+                    //     `infinity / infinity` happens which is `NaN`.
+                    // --> x1 == x2 && y1 == y2
+                    //     Special case from previous one, where the gradient is
+                    //     not infinity but `NaN`. This case can be ignored,
+                    //     because it symbolizes a point to render, and since we
+                    //     render lines there's no need to handle this one.
+                    //     For more efficient handling, this case can be
+                    //     integrated into the previous one, the iteration over
+                    //     y would directly cancel.
+
+                    if (v1[0] == v2[0])
+                    {
+                        auto y_sorted = std::minmax(v1[1], v2[1]);
+                        auto y_start = static_cast<TextSurface::size_type>(
+                            std::max(viewbox.y, y_sorted.first));
+                        // Need to max with 0.0f as a negative value here
+                        // results in an overflow, as TextSurface::size_type
+                        // is unsigned.
+                        auto y_end = static_cast<TextSurface::size_type>(
+                            std::max(
+                                0.0f,
+                                std::min(
+                                    viewbox.y + viewbox.height,
+                                    y_sorted.second)));
+
+                        for (auto y = y_start; y < y_end; y++)
+                        {
+                            (*m_Target)(v1[0], y) = m_RenderChar;
+                        }
+
+                        continue;
+                    }
+
+                    CE3D2::Math::LinearAffineFunction line(
+                        v1[0], v1[1], v2[0], v2[1]);
+
+                    // Calculate the boundaries of the line within a box.
+                    auto viewbox_intersections =
+                        CE3D2::Math::line_intersection_with_box(line, viewbox);
+
+                    if (viewbox_intersections.size() != 2)
+                    {
+                        // If we have less than two intersection, this means
+                        // we only touch the viewbox or don't hit it at all.
+                        // More than two should not occur, but it can happen
+                        // due to numerical limitations.
+                        continue;
+                    }
+
+                    if (fabs(line.get_gradient()) > 1.0f)
+                    {
+                        // Line has more height than width.
+
+                        auto y_viewbox_bounds = std::minmax(
+                            viewbox_intersections[0].second,
+                            viewbox_intersections[1].second);
+
+                        auto y_line_bounds = std::minmax(v1[1], v2[1]);
+
+                        // The first element contains the upper bound, and the
+                        // second element the lower bound.
+                        auto y_bounds_start =
+                            static_cast<TextSurface::size_type>(std::max(
+                                std::round(y_line_bounds.first),
+                                y_viewbox_bounds.first));
+                        // Need to max with 0.0f as a negative value here
+                        // results in an overflow, as TextSurface::size_type
+                        // is unsigned.
+                        auto y_bounds_end =
+                            static_cast<TextSurface::size_type>(std::max(
+                                0.0f,
+                                std::min(
+                                    std::round(y_line_bounds.second),
+                                    y_viewbox_bounds.second)));
+
+                        for (auto y = y_bounds_start; y < y_bounds_end; y++)
+                        {
+                            auto x = static_cast<TextSurface::size_type>(
+                                std::round(line.inverse(
+                                    static_cast<PrecisionType>(y))));
+
+                            // Rounding issues cause x_prev to go still out of
+                            // bounds sometimes.
+                            if (x < viewbox.x + viewbox.width)
+                            {
+                                (*m_Target)(x, y) = m_RenderChar;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Line has more width than height or width is equal to
+                        // height.
+
+                        auto x_viewbox_bounds = std::minmax(
+                            viewbox_intersections[0].first,
+                            viewbox_intersections[1].first);
+
+                        auto x_line_bounds = std::minmax(v1[0], v2[0]);
+
+                        // The first element contains the upper bound, and the
+                        // second element the lower bound.
+                        auto x_bounds_start =
+                            static_cast<TextSurface::size_type>(std::max(
+                                std::round(x_line_bounds.first),
+                                x_viewbox_bounds.first));
+                        // Need to max with 0.0f as a negative value here
+                        // results in an overflow, as TextSurface::size_type
+                        // is unsigned.
+                        auto x_bounds_end =
+                            static_cast<TextSurface::size_type>(std::max(
+                                0.0f,
+                                std::min(
+                                    std::round(x_line_bounds.second),
+                                    x_viewbox_bounds.second)));
+
+                        // Due to integer rounding we could achieve a negative
+                        // function value for our line, resulting in an overflow
+                        // for our target unsigned integral type and so causing
+                        // a segmentation fault.
+                        auto y_prev = static_cast<TextSurface::size_type>(
+                            std::round(line(x_bounds_start)));
+
+                        for (auto x = x_bounds_start; x < x_bounds_end; x++)
+                        {
+                            auto y_next = static_cast<TextSurface::size_type>(
+                                std::round(line(
+                                    static_cast<PrecisionType>(x + 1))));
+
+                            TextSurface::size_type surface_y;
+
+                            if (y_prev == y_next)
+                            {
+                                surface_y = y_prev - 1;
+                            }
+                            else if (y_prev < y_next)
+                            {
+                                surface_y = y_prev;
+                            }
+                            else
+                            {
+                                surface_y = y_next;
+                            }
+
+                            if (surface_y < viewbox.y + viewbox.height)
+                            {
+                                (*m_Target)(x, surface_y) = m_RenderChar;
+                            }
+
+                            y_prev = y_next;
+                        }
                     }
                 }
             }
@@ -308,6 +507,7 @@ namespace Render
         }
 
         render_points();
+        render_dotlines();
         render_lines();
     }
 }

--- a/CE3D2/render/TextRenderer.h
+++ b/CE3D2/render/TextRenderer.h
@@ -74,14 +74,40 @@ namespace Render
         std::vector<std::shared_ptr<CE3D2::Models::Model>> const&
         models() const;
 
+        /// Returns a reference to the dot-line-model list.
+        ///
+        /// Each model inside this list will be rendered using the render-char
+        /// connecting the specified index pairs.
+        ///
+        /// Dot-line-models have higher priority than normal models but less
+        /// priority than line-models!
+        ///
+        /// @returns
+        ///     A reference to the dot-line-model list.
+        std::vector<std::shared_ptr<CE3D2::Models::LineModel>>&
+        dotline_models();
+
+        /// Returns a reference to the dot-line-model list.
+        ///
+        /// Each model inside this list will be rendered using the render-char
+        /// connecting the specified index pairs.
+        ///
+        /// Dot-line-models have higher priority than normal models but less
+        /// priority than line-models!
+        ///
+        /// @returns
+        ///     A read-only reference to the dot-line-model list.
+        std::vector<std::shared_ptr<CE3D2::Models::LineModel>> const&
+        dotline_models() const;
+
         /// Returns a reference to the line-model list.
         ///
         /// Each model inside this list will be rendered using the chars `_`,
         /// `\\`, `|` and `/` connecting the specified index pairs.
         ///
-        /// Line-models have higher priority than normal models, means the line
-        /// connection characters override the dot-characters on the provided
-        /// `TextSurface` target!
+        /// Line-models have higher priority than normal and dot-line models,
+        /// means the line connection characters override the dot-characters
+        /// on the provided `TextSurface` target!
         ///
         /// @returns
         ///     A reference to the line-model list.
@@ -93,9 +119,9 @@ namespace Render
         /// Each model inside this list will be rendered using the chars `_`,
         /// `\\`, `|` and `/` connecting the specified index pairs.
         ///
-        /// Line-models have higher priority than normal models, means the line
-        /// connection characters override the dot-characters on the provided
-        /// `TextSurface` target!
+        /// Line-models have higher priority than normal and dot-line models,
+        /// means the line connection characters override the dot-characters
+        /// on the provided `TextSurface` target!
         ///
         /// @returns
         ///     A read-only reference to the line-model list.
@@ -114,11 +140,13 @@ namespace Render
 
     private:
         void render_points();
+        void render_dotlines();
         void render_lines();
 
         char m_RenderChar;
         std::shared_ptr<TextSurface> m_Target;
         std::vector<std::shared_ptr<CE3D2::Models::Model>> m_Models;
+        std::vector<std::shared_ptr<CE3D2::Models::LineModel>> m_DotlineModels;
         std::vector<std::shared_ptr<CE3D2::Models::LineModel>> m_LineModels;
     };
 }


### PR DESCRIPTION
Renders the same character for each point defined by a line inside
a `LineModel`.

Closes https://github.com/Makman2/CE3D2/issues/117